### PR TITLE
Fix link to service desk

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ To benefit from one of these offers, please submit the Service Desk ticket with 
 
 ### I don't have a ServiceDesk account
 
-Head to https://servicedesk.cncf.io and try to login, if you can't find an account, email info@cncf.io and one will be created for you.
+Head to the [Service Desk](https://cncfservicedesk.atlassian.net/servicedesk/customer/portal/1/user/login) web site and try to login, if you can't find an account, email info@cncf.io and one will be created for you.
 
 ### I changed my email and lost my servicedesk access, what can I do to get it back?
 


### PR DESCRIPTION
The old link never worked for me. The login page it would take me to never seemed to work. It would ack that I exist but said I didn't have an account on the cncf site. I wonder if that login is more for admins. The new link does seem to work. Notice that it's a totally different page - which, again, makes me think the wrong access login portal was being used.