### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ CNCF Projects may freely select their own tools, produce their own documentation
 * [LFX Security](https://lfx.linuxfoundation.org/tools/security/) for the source code security scanning and license compliance [white-labeled Snyk]
 * [Credly](https://info.credly.com) Custom badges powered by Credly (example [Linkerd Hero](https://www.youracclaim.com/badges/538d249f-ec6d-4c5c-93f4-44d7c5596b36/twitter) program)
 * [Scarf](https://scarf.sh) for advanced analytics for container & artifact distribution, package installation, and web traffic to source documentation 
+* [Peritus.ai](https://peritus.ai/) for Machine Learning analytics and self-service for developer communities
 
 CNCF staff is familiar with, and can help projects with, hosting on AWS, GCP, and Azure clouds. In some cases, we have credits available for free hosting. We also have our own [Community Infrastructure Lab](https://www.cncf.io/community/infrastructure-lab/)
 


### PR DESCRIPTION
Adding Peritus.ai as a tool available for all CNCF projects. All heavy lifting is done by the Peritus.ai team. The community maintainers/managers need to install/add the Peritus Slack Applications to their community channels. (CC: @caniszczyk , @amye)