### PR TITLE
Updated Docker OSS application link

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ CNCF expects fair usage of the allocated resources and credits, and reserves the
 
 In 2020, Docker announced the changes to [image retention](https://www.docker.com/blog/scaling-dockers-business-to-serve-millions-more-developers-storage/) and [data pull rates](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/).
 
-CNCF has reached an agreement with Docker that these limits can be eliminated for the CNCF projects - if your project is affected by these changes, please consider applying to the [Docker Expanded Support for Open Source Software Projects](https://www.docker.com/blog/expanded-support-for-open-source-software-projects/) program via the [form](https://www.docker.com/open-source-application).
+CNCF has reached an agreement with Docker that these limits can be eliminated for the CNCF projects - if your project is affected by these changes, please consider applying to the [Docker Expanded Support for Open Source Software Projects](https://www.docker.com/blog/expanded-support-for-open-source-software-projects/) program via the [form](https://www.docker.com/community/open-source/application/).
 
 NOTE: To have you application processed correctly by Docker, please explicitly mention that your project is hosted by CNCF. Also, please note that the approval process may take up to a few weeks.
 


### PR DESCRIPTION
Signed-off-by: Steven Powell <spowellgrr@gmail.com>

The Docker OSS application form has moved, the current one redirects to a general page with no link to the application.