### PR TITLE
Update project security audits link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ CNCF staff is available to assist and guide your project. Below are some of the 
 * Project governance creation and advice
 * Facilitating community meetings with support for online participation 
 * Administrative support for communication and project processes
-* [Security audits](https://github.com/cncf/toc/blob/master/docs/projects.md#project-audits) by independent third parties (e.g., Kubernetes security audit)
+* [Security audits](https://github.com/cncf/toc/blob/master/docs/projects.md#project-security-audits) by independent third parties (e.g., Kubernetes security audit)
 * Distributed systems safety research via independent third parties (e.g. https://jepsen.io/)
 * Biweekly or monthly check in meetings with CNCF Staff as requested
 * Project activity tracking and contribution reporting via https://devstats.cncf.io


### PR DESCRIPTION
This PR simply updates the link on the main README.md page for project security audits.  The link target had a slight change in the header, which broke the link.

I've tested this by clicking the updated link in my fork: https://github.com/jbw976/servicedesk/blob/sec-audit-link/README.md 